### PR TITLE
Backport fix for split_region()

### DIFF
--- a/qemu/target-i386/misc_helper.c
+++ b/qemu/target-i386/misc_helper.c
@@ -222,7 +222,7 @@ void helper_rdtsc(CPUX86State *env)
         if (!HOOK_BOUND_CHECK(hook, env->eip))
             continue;
         if (hook->insn == UC_X86_INS_RDTSC)
-            ((uc_cb_insn_syscall_t)hook->callback)(env->uc, &rdtsc_q, hook->user_data);
+            ((uc_cb_insn_rdtsc_t)hook->callback)(env->uc, &rdtsc_q, hook->user_data);
     }
 
     env->regs[R_EAX] = rdtsc_q.eax;

--- a/uc.c
+++ b/uc.c
@@ -367,7 +367,7 @@ uc_err uc_close(uc_engine *uc)
     // finally, free uc itself.
     memset(uc, 0, sizeof(*uc));
     free(uc);
-    
+
     return UC_ERR_OK;
 }
 
@@ -549,7 +549,7 @@ static void clear_deleted_hooks(uc_engine *uc)
     struct list_item * cur;
     struct hook * hook;
     int i;
-    
+
     for (cur = uc->hooks_to_del.head; cur != NULL && (hook = (struct hook *)cur->data); cur = cur->next) {
         assert(hook->to_delete);
         for (i = 0; i < UC_HOOK_MAX; i++) {
@@ -866,7 +866,9 @@ static bool split_region(struct uc_struct *uc, MemoryRegion *mr, uint64_t addres
         return false;
 
     QTAILQ_FOREACH(block, &uc->ram_list.blocks, next) {
-        if (block->offset <= mr->addr && block->length >= (mr->end - mr->addr)) {
+        //if (block->offset <= mr->addr && block->length >= (mr->end - mr->addr)) {
+        /* backported fix according to commits c733bba and 9651863 */
+        if (block->mr->addr <= mr->addr && block->length + block->mr->addr >= mr->end) {
             break;
         }
     }


### PR DESCRIPTION
Issue is observed when uc_mem_protect() is called for a page within a multi-plage region. In this case the region is incorrectly split resulting memory parts zeroed completely. Found some changes in upstream that probably addressed the very same issue. (commits 9651863 and c733bba)

Also removed a warning that made linux compilation fail.